### PR TITLE
WIP HPT-1394 persisting structure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :development, :test do
   gem 'solr_wrapper', '>= 0.3'
   gem 'fcrepo_wrapper'
   gem 'rspec-rails'
+  gem 'rails-controller-testing'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -559,6 +559,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.1.6)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.2)
+      actionpack (~> 5.x, >= 5.0.1)
+      actionview (~> 5.x, >= 5.0.1)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -822,6 +826,7 @@ DEPENDENCIES
   omniauth-cas
   puma (~> 3.7)
   rails (~> 5.1.6)
+  rails-controller-testing
   riiif (~> 1.1)
   rsolr (~> 2.0)
   rspec-rails

--- a/app/controllers/hyrax/paged_resources_controller.rb
+++ b/app/controllers/hyrax/paged_resources_controller.rb
@@ -17,5 +17,11 @@ module Hyrax
       @members = presenter.member_presenters
       @logical_order = presenter.logical_order_object
     end
+
+    def save_structure
+      structure = { "label": params["label"], "nodes": params["nodes"] }
+      SaveStructureJob.perform_later(curation_concern, structure.to_json)
+      head 200
+    end
   end
 end

--- a/app/controllers/hyrax/paged_resources_controller.rb
+++ b/app/controllers/hyrax/paged_resources_controller.rb
@@ -11,5 +11,11 @@ module Hyrax
 
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::PagedResourcePresenter
+
+    def structure
+      parent_presenter
+      @members = presenter.member_presenters
+      @logical_order = presenter.logical_order_object
+    end
   end
 end

--- a/app/jobs/concerns/lockable_job.rb
+++ b/app/jobs/concerns/lockable_job.rb
@@ -1,0 +1,42 @@
+module LockableJob
+  extend ActiveSupport::Concern
+
+  def self.prepended(mod) # rubocop:disable Metrics/AbcSize
+    mod.class_eval do
+      before_enqueue do |job|
+        job.arguments << { lock_info: job_subject(job).lock }
+      end
+
+      before_perform do |job|
+        unless lock_info?(job.arguments)
+          job.arguments << { lock_info: job_subject(job).lock }
+        end
+      end
+
+      after_perform do |job|
+        job_subject(job).try :unlock, job.arguments.last[:lock_info]
+      end
+    end
+  end
+
+  def perform(*args)
+    args.pop if lock_info?(args) # Run the job with only the original arguments
+    super(*args)
+  end
+
+  # Default behavior assumes the first argument of the extended job is an
+  # actual object that includes ExtraLockable.
+  def job_subject(job)
+    if defined?(super)
+      super
+    else
+      job.arguments.first
+    end
+  end
+
+  private
+
+    def lock_info?(args)
+      args.last.is_a?(Hash) && args.last.key?(:lock_info)
+    end
+end

--- a/app/jobs/save_structure_job.rb
+++ b/app/jobs/save_structure_job.rb
@@ -1,0 +1,24 @@
+class SaveStructureJob < ActiveJob::Base
+  prepend ::LockableJob
+  queue_as :default
+
+  # rubocop:disable Metrics/AbcSize
+  def perform(curation_concern, structure)
+    return unless curation_concern.respond_to?(:logical_order)
+    # Remove existing logical order object to avoid accumulation of fragments.
+    curation_concern.logical_order.destroy eradicate: true
+    curation_concern.reload
+    curation_concern.logical_order.order = JSON.parse(structure)
+    curation_concern.save
+    if !curation_concern.persisted? ||
+       !curation_concern.logical_order.persisted?
+      raise ActiveFedora::RecordNotSaved,
+            "#{curation_concern.id} logical order not saved!"
+    end
+  rescue StandardError
+    Rails.logger.error "SaveStructureJob failed on #{curation_concern.id}!" \
+    " Following structure may not be persisted:\n#{structure}"
+    raise
+  end
+  # rubocop:ensable Metrics/AbcSize
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,6 +6,7 @@ class Ability
 
   # Define any customized permissions here.
   def custom_permissions
+    can %i[file_manager save_structure structure], PagedResource
     # Limits deleting objects to a the admin user
     #
     # if current_user.admin?

--- a/app/models/concerns/extra_lockable.rb
+++ b/app/models/concerns/extra_lockable.rb
@@ -1,0 +1,39 @@
+module ExtraLockable
+  extend ActiveSupport::Concern
+  include Hyrax::Lockable
+
+  included do
+    class_attribute :lock_id_attribute
+    self.lock_id_attribute = :id
+
+    # TODO: Handle when id is nil or not defined.
+    def lock_id
+      ident = try(lock_id_attribute)
+      raise ArgumentError, "lock id attribute cannot be blank" if ident.blank?
+      "lock_#{ident}"
+    end
+
+    # Provides a way to pass options to the underlying Redlock client.
+    def lock(key = lock_id, options = {})
+      ttl = options.delete(:ttl) || Hyrax.config.lock_time_to_live
+      if block_given?
+        lock_manager.client.lock(key, ttl, options, &Proc.new)
+      else
+        lock_manager.client.lock(key, ttl, options)
+      end
+    end
+
+    def lock?(key = lock_id)
+      acquire_lock_for(key) { nil }
+      Rails.logger.info "ExtraLockable: No lock found for key: #{key}"
+      return false
+    rescue Hyrax::LockManager::UnableToAcquireLockError
+      Rails.logger.info "ExtraLockable: Found a lock for key: #{key}"
+      return true
+    end
+
+    def unlock(lock_info)
+      lock_manager.client.unlock lock_info
+    end
+  end
+end

--- a/app/models/concerns/logical_order.rb
+++ b/app/models/concerns/logical_order.rb
@@ -1,0 +1,106 @@
+##
+# Object responsible for iterating over a params representation of a logical
+# order.
+class LogicalOrder
+  attr_reader :order_hash, :node_class, :top
+  attr_writer :rdf_subject
+  # @param [Hash] order_hash The params representation of the order.
+  # @param [RDF::URI] rdf_subject The subject of the head node
+  # @param [#new] node_class The factory to generate child nodes.
+  # @example
+  #   LogicalOrder.new({"nodes": [ { "proxy": "a" } ]},
+  #     RDF::URI("http://test.com"), LogicalOrder)
+  def initialize(order_hash = {},
+                 rdf_subject = nil,
+                 node_class = LogicalOrder,
+                 top = true)
+    @order_hash = order_hash.with_indifferent_access
+    @rdf_subject = RDF::URI(rdf_subject.to_s) if rdf_subject
+    @node_class = node_class
+    @top = top
+  end
+
+  # @return [Array<node_class>] Child nodes of this resource.
+  def nodes
+    @nodes ||= order_hash.fetch("nodes", []).map do |values|
+      node_class.new(values, nil, node_class, false)
+    end
+  end
+
+  # @return [String] Label of the top level node.
+  def label
+    order_hash.fetch("label", nil)
+  end
+
+  # @return [String] Label for the form.
+  def form_label
+    label || default_label
+  end
+
+  # @return [::RDF::Graph] Ordered graph representation of the given ordered
+  #   hash.
+  def to_graph # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    self_graph = ordered_list.to_graph
+    self_graph = ActiveTriples::Resource.new(rdf_subject, data: self_graph)
+    self_graph << [rdf_subject, RDF::Vocab::RDFS.label, label] if label
+    nodes.each do |node|
+      self_graph << node.to_graph
+    end
+    if nodes.any?
+      self_graph << [rdf_subject,
+                     RDF::Vocab::IANA.first,
+                     nodes.first.rdf_subject]
+      self_graph << [rdf_subject,
+                     RDF::Vocab::IANA.last,
+                     nodes.last.rdf_subject]
+    end
+    self_graph
+  end
+
+  # @return [String] ID of this node.
+  def id
+    rdf_subject.to_s if rdf_subject.to_s.start_with?("#")
+  end
+
+  # @return [RDF::URI] URI of the resource this node is a proxy for.
+  def proxy_for
+    ActiveFedora::Base.id_to_uri(order_hash["proxy"]) if proxy_for_id
+  end
+
+  # @return [String] ID of the resource this node is a proxy for.
+  def proxy_for_id
+    order_hash["proxy"]
+  end
+
+  # @return [::RDF::URI] URI of this node.
+  def rdf_subject
+    @rdf_subject ||= ordered_list.send(:new_node_subject)
+  end
+
+  def each_section(&block)
+    return enum_for(:each_section) unless block_given?
+    nodes.each do |node|
+      yield node if node.proxy_for.blank?
+      node.send(:each_section, &block)
+    end
+  end
+
+  private
+
+    def ordered_list
+      @ordered_list ||=
+        begin
+          o = ActiveFedora::Orders::OrderedList \
+              .new(::ActiveTriples::Resource.new, nil, nil)
+          nodes.each do |node|
+            o.insert_proxy_for_at(o.length, node.proxy_for)
+            node.rdf_subject = o.last.rdf_subject
+          end
+          o
+        end
+    end
+
+    def default_label
+      "Logical" if top
+    end
+end

--- a/app/models/concerns/logical_order_graph.rb
+++ b/app/models/concerns/logical_order_graph.rb
@@ -1,0 +1,60 @@
+##
+# Primarily responsible for going from an ordered graph to a params
+#   representation of an order.
+class LogicalOrderGraph
+  attr_reader :graph, :head_subject
+  # @param [::RDF::Enumerable] graph Graph to parse.
+  # @param [::RDF::URI] head_subject The subject of the top node in the ordered
+  #   list.
+  def initialize(graph, head_subject)
+    @graph = graph
+    @head_subject = head_subject
+  end
+
+  # @return [Hash] The params representation of an order.
+  def to_h # rubocop:disable Metrics/AbcSize
+    hsh = {}
+    hsh["label"] = label if label.present? && label.to_s != head_subject.to_s
+    hsh["nodes"] = nodes.map(&:to_h) unless nodes.empty?
+    hsh["proxy"] = proxy_for_id if proxy_for_id
+    hsh.with_indifferent_access
+  end
+
+  # @return [Array<LogicalOrderGraph>] Child nodes of this resource.
+  def nodes
+    ordered_list.map do |x|
+      LogicalOrderGraph.new(graph, x.rdf_subject)
+    end
+  end
+
+  # @return [String] Label of the top level node.
+  def label
+    node.rdf_label.first
+  end
+
+  # @return [String] ID of the resource this node is a proxy for.
+  def proxy_for_id
+    ActiveFedora::Base.uri_to_id(node.proxy_for.first) if node.proxy_for.first
+  end
+
+  private
+
+    def node
+      @node ||= Node.new(head_subject, data: graph)
+    end
+
+    def ordered_list
+      @ordered_list ||=
+        ActiveFedora::Orders::OrderedList.new(graph,
+                                              node.first_ordered.first,
+                                              node.last_ordered.first)
+    end
+
+    class Node < ActiveTriples::Resource
+      property :prev, predicate: ::RDF::Vocab::IANA.prev, cast: false
+      property :next, predicate: ::RDF::Vocab::IANA.next, cast: false
+      property :first_ordered, predicate: ::RDF::Vocab::IANA.first, cast: false
+      property :last_ordered, predicate: ::RDF::Vocab::IANA.last, cast: false
+      property :proxy_for, predicate: ::RDF::Vocab::ORE.proxyFor, cast: false
+    end
+end

--- a/app/models/concerns/structural_metadata.rb
+++ b/app/models/concerns/structural_metadata.rb
@@ -1,0 +1,18 @@
+module StructuralMetadata
+  extend ActiveSupport::Concern
+
+  included do
+    has_subresource :logical_order, class_name: "LogicalOrderBase"
+  end
+
+  def to_solr(solr_doc = {})
+    super.tap do |doc|
+      doc[ActiveFedora.index_field_mapper.solr_name("logical_order",
+                                                    :stored_searchable)] =
+        [logical_order.order.to_json]
+      doc[ActiveFedora.index_field_mapper.solr_name("logical_order_headings",
+                                                    :stored_searchable)] =
+        logical_order.object.each_section.map(&:label)
+    end
+  end
+end

--- a/app/models/logical_order_base.rb
+++ b/app/models/logical_order_base.rb
@@ -1,0 +1,48 @@
+class LogicalOrderBase < ActiveFedora::Base
+  property :label, predicate: ::RDF::Vocab::RDFS.label
+  property :nodes, predicate: ::RDF::Vocab::DC.hasPart
+  property :head, predicate: ::RDF::Vocab::IANA['first'], multiple: false
+  property :tail, predicate: ::RDF::Vocab::IANA.last, multiple: false
+
+  def order=(order) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    nodes_will_change!
+    head_will_change!
+    tail_will_change!
+    label_will_change!
+    order = LogicalOrder.new(order, ::RDF::URI(rdf_subject))
+    graph = order.to_graph
+    # Delete old statements
+    subj = resource.subjects.to_a.select do |x|
+      x.to_s.split("/").last.to_s.include?("#g")
+    end
+    subj.each do |s|
+      resource.delete [s, nil, nil]
+    end
+    self.head = nil
+    self.tail = nil
+    self.label = nil
+    resource << graph
+    # Set nodes so that hash URIs get persisted to Fedora.
+    self.nodes = graph.subjects.reject { |x| x == rdf_subject }
+    @order = nil
+    @logical_order = nil
+  end
+
+  def order
+    @order ||= LogicalOrderGraph.new(resource, rdf_subject).to_h
+  end
+
+  def object
+    @logical_order ||= LogicalOrder.new(order)
+  end
+
+  # Not useful and slows down indexing.
+  def create_date
+    nil
+  end
+
+  # Not useful, slows down indexing.
+  def modified_date
+    nil
+  end
+end

--- a/app/models/paged_resource.rb
+++ b/app/models/paged_resource.rb
@@ -3,6 +3,8 @@
 class PagedResource < ActiveFedora::Base
   include Catorax::PagedResourceBehavior
   include ::Hyrax::WorkBehavior
+  include ::StructuralMetadata
+  include ExtraLockable
 
   self.indexer = PagedResourceIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/presenters/hyrax/paged_resource_presenter.rb
+++ b/app/presenters/hyrax/paged_resource_presenter.rb
@@ -2,5 +2,9 @@
 #  `rails generate hyrax:work PagedResource`
 module Hyrax
   class PagedResourcePresenter < Hyrax::WorkShowPresenter
+    def logical_order_object
+      @logical_order_object ||=
+          logical_order_factory.new(logical_order, nil, logical_order_factory)
+    end
   end
 end

--- a/app/views/hyrax/paged_resources/_structure_node.html.erb
+++ b/app/views/hyrax/paged_resources/_structure_node.html.erb
@@ -1,0 +1,39 @@
+<%= content_tag "li", data: { id: node.id, proxy: node.proxy_for_id }.compact, class: (node.proxy_for_id ? 'mjs-nestedSortable-no-nesting' : '') do %>
+  <div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <div class="row">
+          <div class="title">
+            <span class="move glyphicon glyphicon-move"></span>
+            <span class="expand-collapse glyphicon"></span>
+            <% if !node.proxy_for_object %>
+              <%= text_field_tag "label", node.label %>
+            <% else %>
+              <%= node.proxy_for_object || node.label %>
+            <% end %>
+          </div>
+          <div class="toolbar">
+            <% if !node.proxy_for_object %>
+              <a href="" title="Remove" data-action="remove-list"><span class="glyphicon glyphicon-remove"></span></a>
+            <% end %>
+          </div>
+        </div>
+      </div>
+      <% if node.proxy_for_id %>
+        <div class="panel-body">
+          <%= osd_modal_for(node.proxy_for_object.thumbnail_id) do %>
+            <%= render_thumbnail_tag(node.proxy_for_object, onerror: default_icon_fallback)%>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+  <% if node.nodes.any? %>
+    <ul>
+      <% node.nodes.each do |order| %>
+        <%= render "structure_node", node: order %>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>
+</li>

--- a/app/views/hyrax/paged_resources/structure.html.erb
+++ b/app/views/hyrax/paged_resources/structure.html.erb
@@ -1,0 +1,30 @@
+<%= structure_page_header %>
+
+<div id="list-toolbar">
+  <a href="" data-action="add-to-list">
+    <button class="btn btn-default">
+      <span class="glyphicon glyphicon-plus"></span>
+      Add a Section
+    </button>
+  </a>
+  <!--<button data-action="submit-list" class="btn btn-primary">Save</button>-->
+  <%= button_tag type: 'button', class: 'btn btn-primary',
+                 data: { action: 'submit-list',
+                         prefix: Rails.application.config.relative_url_root || '' } do %>
+    Save
+  <% end %>
+</div>
+<ul class="sortable" data-id="<%= @presenter.id %>" data-class-name="<%= @presenter.model_name.plural %>">
+  <form class="form-inline">
+    <div class="form-group">
+      <label for="structure_label">Structure Label</label>
+      <%= text_field_tag "label", @logical_order.form_label, id: "structure_label", class: "form-control" %>
+    </div>
+  </form>
+  <% @logical_order.nodes.each do |node| %>
+    <%= render "structure_node", node: node %>
+  <% end %>
+  <% @logical_order.unstructured_objects.nodes.each do |node| %>
+    <%= render "structure_node", node: node %>
+  <% end %>
+</ul>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  #
+  config.active_job.queue_adapter = :inline
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,14 +26,8 @@ Rails.application.routes.draw do
   namespace :hyrax, path: :concern do
     resources :paged_resources, only: [] do
       member do
-        get "/pdf/:pdf_quality", action: :pdf, as: :pdf
-        get "/highlight/:search_term", action: :show
-        patch :alphabetize_members
         get :structure
         post :structure, action: :save_structure
-        get :manifest, defaults: { format: :json }
-        post :browse_everything_files
-        post :flag
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,21 @@ Rails.application.routes.draw do
   resources :welcome, only: 'index'
   root 'hyrax/homepage#index'
   curation_concerns_basic_routes
+  namespace :hyrax, path: :concern do
+    resources :paged_resources, only: [] do
+      member do
+        get "/pdf/:pdf_quality", action: :pdf, as: :pdf
+        get "/highlight/:search_term", action: :show
+        patch :alphabetize_members
+        get :structure
+        post :structure, action: :save_structure
+        get :manifest, defaults: { format: :json }
+        post :browse_everything_files
+        post :flag
+      end
+    end
+  end
+
   concern :exportable, Blacklight::Routes::Exportable.new
 
   resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do

--- a/spec/actors/hyrax/actors/bib_record_actor_spec.rb
+++ b/spec/actors/hyrax/actors/bib_record_actor_spec.rb
@@ -3,7 +3,5 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::Actors::BibRecordActor do
-  it "has tests" do
-    skip "Add your tests here"
-  end
+  # "Add your tests here"
 end

--- a/spec/actors/hyrax/actors/image_actor_spec.rb
+++ b/spec/actors/hyrax/actors/image_actor_spec.rb
@@ -3,7 +3,5 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::Actors::ImageActor do
-  it "has tests" do
-    skip "Add your tests here"
-  end
+  # "Add your tests here"
 end

--- a/spec/actors/hyrax/actors/paged_resource_actor_spec.rb
+++ b/spec/actors/hyrax/actors/paged_resource_actor_spec.rb
@@ -3,7 +3,5 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::Actors::PagedResourceActor do
-  it "has tests" do
-    skip "Add your tests here"
-  end
+  # "Add your tests here"
 end

--- a/spec/controllers/hyrax/bib_records_controller_spec.rb
+++ b/spec/controllers/hyrax/bib_records_controller_spec.rb
@@ -3,7 +3,5 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::BibRecordsController do
-  it "has tests" do
-    skip "Add your tests here"
-  end
+  # "Add your tests here"
 end

--- a/spec/controllers/hyrax/images_controller_spec.rb
+++ b/spec/controllers/hyrax/images_controller_spec.rb
@@ -3,7 +3,5 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::ImagesController do
-  it "has tests" do
-    skip "Add your tests here"
-  end
+  # "Add your tests here"
 end

--- a/spec/controllers/hyrax/paged_resources_controller_spec.rb
+++ b/spec/controllers/hyrax/paged_resources_controller_spec.rb
@@ -3,9 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::PagedResourcesController do
-  it "has tests" do
-    skip "Add your tests here"
-  end
   include_examples("structure persister",
                    :paged_resource,
                    Hyrax::PagedResourcePresenter)

--- a/spec/controllers/hyrax/paged_resources_controller_spec.rb
+++ b/spec/controllers/hyrax/paged_resources_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::PagedResourcesController do
-  include_examples("structure persister",
+  include_examples("paged_structure persister",
                    :paged_resource,
                    Hyrax::PagedResourcePresenter)
 end

--- a/spec/controllers/hyrax/paged_resources_controller_spec.rb
+++ b/spec/controllers/hyrax/paged_resources_controller_spec.rb
@@ -6,4 +6,7 @@ RSpec.describe Hyrax::PagedResourcesController do
   it "has tests" do
     skip "Add your tests here"
   end
+  include_examples("structure persister",
+                   :paged_resource,
+                   Hyrax::ImagePresenter)
 end

--- a/spec/controllers/hyrax/paged_resources_controller_spec.rb
+++ b/spec/controllers/hyrax/paged_resources_controller_spec.rb
@@ -8,5 +8,5 @@ RSpec.describe Hyrax::PagedResourcesController do
   end
   include_examples("structure persister",
                    :paged_resource,
-                   Hyrax::ImagePresenter)
+                   Hyrax::PagedResourcePresenter)
 end

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -1,0 +1,21 @@
+FactoryBot.define do
+  # The ::FileSet model is defined in spec/internal/app/models by the
+  # curation_concerns:install generator.
+  factory :file_set, class: FileSet do
+
+    transient do
+      user { FactoryBot.create(:user) }
+      content nil
+    end
+
+    after(:create) do |file, evaluator|
+      if evaluator.content
+        Hydra::Works::UploadFileToFileSet.call(file, evaluator.content)
+      end
+    end
+
+    after(:build) do |file, evaluator|
+      file.apply_depositor_metadata(evaluator.user.user_key)
+    end
+  end
+end

--- a/spec/factories/paged_resources.rb
+++ b/spec/factories/paged_resources.rb
@@ -11,5 +11,9 @@ FactoryBot.define do
     transient do
       user { FactoryBot.create(:user) }
     end
+
+    after(:build) do |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user.user_key)
+    end
   end
 end

--- a/spec/factories/paged_resources.rb
+++ b/spec/factories/paged_resources.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :paged_resource do
+    title ["Test title"]
+    # source_metadata_identifier "1234567"
+    rights_statement ["http://rightsstatements.org/vocab/NKC/1.0/"]
+    description ["900 years of time and space, and I’ve never been slapped" \
+    " by someone’s mother."]
+    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    state "complete"
+
+    transient do
+      user { FactoryBot.create(:user) }
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,12 +2,10 @@ require 'factory_girl'
 
 FactoryGirl.define do
   factory :user do
-    sequence(:username) { |n| "username#{n}" }
+    sequence(:uid) { |n| "username#{n}" }
     sequence(:email) { |n| "email-#{srand}@test.com" }
     provider 'cas'
-    uid do |user|
-      user.username
-    end
+
     factory :admin do
       roles { [Role.where(name: 'admin').first_or_create] }
     end

--- a/spec/forms/hyrax/bib_record_form_spec.rb
+++ b/spec/forms/hyrax/bib_record_form_spec.rb
@@ -3,7 +3,5 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::BibRecordForm do
-  it "has tests" do
-    skip "Add your tests here"
-  end
+    # "Add your tests here"
 end

--- a/spec/forms/hyrax/image_form_spec.rb
+++ b/spec/forms/hyrax/image_form_spec.rb
@@ -3,7 +3,5 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::ImageForm do
-  it "has tests" do
-    skip "Add your tests here"
-  end
+  # "Add your tests here"
 end

--- a/spec/forms/hyrax/paged_resource_form_spec.rb
+++ b/spec/forms/hyrax/paged_resource_form_spec.rb
@@ -3,7 +3,5 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::PagedResourceForm do
-  it "has tests" do
-    skip "Add your tests here"
-  end
+  # "Add your tests here"
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,7 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Collection do
-  it "has tests" do
-    skip "Add your tests here"
-  end
+  # "Add your tests here"
 end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -1,7 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe FileSet do
-  it "has tests" do
-    skip "Add your tests here"
-  end
+  # "Add your tests here"
 end

--- a/spec/models/qa/local_authority_entry_spec.rb
+++ b/spec/models/qa/local_authority_entry_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Qa::LocalAuthorityEntry, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+
 end

--- a/spec/models/qa/local_authority_spec.rb
+++ b/spec/models/qa/local_authority_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Qa::LocalAuthority, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+
 end

--- a/spec/presenters/hyrax/bib_record_presenter_spec.rb
+++ b/spec/presenters/hyrax/bib_record_presenter_spec.rb
@@ -3,7 +3,5 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::BibRecordPresenter do
-  it "has tests" do
-    skip "Add your tests here"
-  end
+  # "Add your tests here"
 end

--- a/spec/presenters/hyrax/image_presenter_spec.rb
+++ b/spec/presenters/hyrax/image_presenter_spec.rb
@@ -3,7 +3,5 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::ImagePresenter do
-  it "has tests" do
-    skip "Add your tests here"
-  end
+  # "Add your tests here"
 end

--- a/spec/presenters/hyrax/paged_resource_presenter_spec.rb
+++ b/spec/presenters/hyrax/paged_resource_presenter_spec.rb
@@ -3,7 +3,5 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::PagedResourcePresenter do
-  it "has tests" do
-    skip "Add your tests here"
-  end
+  # "Add your tests here"
 end

--- a/spec/support/shared_examples/paged_structured_controller.rb
+++ b/spec/support/shared_examples/paged_structured_controller.rb
@@ -55,7 +55,7 @@ do |resource_symbol, presenter_factory|
 
       let(:resource) { FactoryBot.create(resource_symbol, user: user) }
       let(:file_set) { FactoryBot.create(:file_set, user: user) }
-      #let(:user) { FactoryBot.create(:admin) }
+      let(:user) { FactoryBot.create(:admin) }
       let(:nodes) do
         [
             {
@@ -76,7 +76,6 @@ do |resource_symbol, presenter_factory|
       end
 
       it "persists order" do
-        pending "Waiting for implementation"
         post :save_structure, params: {nodes: nodes, id: resource.id, label: "TOP!"}
 
         expect(response.status).to eq 200
@@ -84,6 +83,5 @@ do |resource_symbol, presenter_factory|
         .to eq({ "label": "TOP!", "nodes": nodes }.with_indifferent_access)
       end
     end
-
   end
 end

--- a/spec/support/shared_examples/structural_metadata.rb
+++ b/spec/support/shared_examples/structural_metadata.rb
@@ -1,0 +1,118 @@
+RSpec.shared_examples "structural metadata" do
+  describe "#logical_order" do
+    # rubocop:enable RSpec/DescribeClass
+    let(:params) do
+      {
+        "label": "Top!",
+        "nodes": [
+          {
+            "label": "Chapter 1",
+            "nodes": [
+              {
+                "label": resource1.rdf_label.first,
+                "proxy": resource1.id
+              }
+            ]
+          },
+          {
+            "label": "Chapter 2",
+            "nodes": [
+              {
+                "label": resource2.rdf_label.first,
+                "proxy": resource2.id
+              }
+            ]
+          }
+        ]
+      }
+    end
+    let(:params2) do
+      {
+        "nodes": [
+          {
+            "label": "Chapter 1",
+            "nodes": [
+              {
+                "label": resource1.rdf_label.first,
+                "proxy": resource1.id
+              }
+            ]
+          },
+          {
+            "label": "Chapter 2",
+            "nodes": [
+              {
+                "label": "Chapter 2b",
+                "nodes": [
+                  {
+                    "label": resource2.rdf_label.first,
+                    "proxy": resource2.id
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    end
+    let(:resource1) { FactoryGirl.create(:file_set) }
+    let(:resource2) { FactoryGirl.create(:file_set) }
+
+    it "is a resource that can have an order" do
+      expect(curation_concern.logical_order).to be_kind_of LogicalOrderBase
+    end
+    it "can have an order assigned" do
+      curation_concern.logical_order.order = params
+
+      expect(curation_concern.logical_order.resource.statements.to_a.length).to eq 20
+    end
+    it "marshals logical order into solr" do
+      curation_concern.logical_order.order = params
+      curation_concern.save
+      expect(curation_concern.to_solr["logical_order_tesim"]) \
+        .to eq [curation_concern.logical_order.order.to_json]
+    end
+    it "indexes the headings into the solr record" do
+      curation_concern.logical_order.order = params2
+      curation_concern.save
+
+      expect(curation_concern.to_solr["logical_order_headings_tesim"]).to eq [
+        "Chapter 1",
+        "Chapter 2",
+        "Chapter 2b"
+      ]
+    end
+    it "can index even without order" do
+      expect(curation_concern.to_solr["logical_order_headings_tesim"]).to eq []
+    end
+    it "survives persistence" do
+      curation_concern.logical_order.order = params
+      curation_concern.save
+
+      expect(curation_concern.reload.logical_order.order) \
+        .to eq params.with_indifferent_access
+    end
+    it "can have order pulled out of solr" do
+      curation_concern.logical_order.order = params
+      curation_concern.save
+
+      doc =
+        SolrDocument.new(ActiveFedora::SolrService.query("id:#{curation_concern.id}") \
+                           .first)
+      expect(doc.logical_order).to eq curation_concern.logical_order.order
+    end
+    it "has no order by default" do
+      expect(curation_concern.logical_order.order).to eq({})
+    end
+    it "can have order re-assigned" do
+      curation_concern.logical_order.order = params
+      curation_concern.save
+      curation_concern.reload
+      curation_concern.logical_order.order = params2
+      curation_concern.save
+
+      expect(curation_concern.reload.logical_order.order) \
+        .to eq params2.with_indifferent_access
+    end
+  end
+end

--- a/spec/support/shared_examples/structured_controller.rb
+++ b/spec/support/shared_examples/structured_controller.rb
@@ -8,7 +8,6 @@ do |resource_symbol, presenter_factory|
     let(:user) { FactoryBot.create(:user) }
     describe "#structure" do
 
-
       let(:solr) { ActiveFedora.solr.conn }
       let(:resource) do
         r = FactoryBot.build(resource_symbol)
@@ -23,6 +22,7 @@ do |resource_symbol, presenter_factory|
       end
 
       before do
+        allow(resource.class).to receive(:find).and_return(resource)
         # Create a single action that can be taken
         Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
 
@@ -42,21 +42,24 @@ do |resource_symbol, presenter_factory|
       end
 
       it "sets @members" do
-        get :structure, id: "1"
+        pending "Waiting for implementation"
+        get :structure, params: {id: resource.id}
 
         expect(assigns(:members).map(&:id)).to eq ["2"]
       end
       it "sets @logical_order" do
+        pending "Waiting for implementation"
         obj = instance_double("logical order object")
         allow_any_instance_of(presenter_factory) \
         .to receive(:logical_order_object).and_return(obj)
-        get :structure, id: "1"
+        get :structure, params: {id: resource.id}
 
         expect(assigns(:logical_order)).to eq obj
       end
     end
 
     describe "#save_structure" do
+
       let(:resource) { FactoryBot.create(resource_symbol, user: user) }
       let(:file_set) { FactoryBot.create(:file_set, user: user) }
       #let(:user) { FactoryBot.create(:admin) }
@@ -80,7 +83,8 @@ do |resource_symbol, presenter_factory|
       end
 
       it "persists order" do
-        post :save_structure, nodes: nodes, id: resource.id, label: "TOP!"
+        pending "Waiting for implementation"
+        post :save_structure, params: {nodes: nodes, id: resource.id, label: "TOP!"}
 
         expect(response.status).to eq 200
         expect(resource.reload.logical_order.order) \

--- a/spec/support/shared_examples/structured_controller.rb
+++ b/spec/support/shared_examples/structured_controller.rb
@@ -1,0 +1,92 @@
+RSpec.shared_examples "structure persister" \
+do |resource_symbol, presenter_factory|
+  describe "when logged in" do
+
+    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+    let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
+    let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+    let(:user) { FactoryBot.create(:user) }
+    describe "#structure" do
+
+
+      let(:solr) { ActiveFedora.solr.conn }
+      let(:resource) do
+        r = FactoryBot.build(resource_symbol)
+        allow(r).to receive(:id).and_return("1")
+        allow(r.list_source).to receive(:id).and_return("3")
+        r
+      end
+      let(:file_set) do
+        f = FactoryBot.build(:file_set)
+        allow(f).to receive(:id).and_return("2")
+        f
+      end
+
+      before do
+        # Create a single action that can be taken
+        Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+
+        # Grant the user access to deposit into the admin set.
+        Hyrax::PermissionTemplateAccess.create!(
+            permission_template_id: permission_template.id,
+            agent_type: 'user',
+            agent_id: user.user_key,
+            access: 'deposit'
+        )
+        sign_in user
+        resource.ordered_members << file_set
+        solr.add file_set.to_solr.merge(ordered_by_ssim: [resource.id])
+        solr.add resource.to_solr
+        solr.add resource.list_source.to_solr
+        solr.commit
+      end
+
+      it "sets @members" do
+        get :structure, id: "1"
+
+        expect(assigns(:members).map(&:id)).to eq ["2"]
+      end
+      it "sets @logical_order" do
+        obj = instance_double("logical order object")
+        allow_any_instance_of(presenter_factory) \
+        .to receive(:logical_order_object).and_return(obj)
+        get :structure, id: "1"
+
+        expect(assigns(:logical_order)).to eq obj
+      end
+    end
+
+    describe "#save_structure" do
+      let(:resource) { FactoryBot.create(resource_symbol, user: user) }
+      let(:file_set) { FactoryBot.create(:file_set, user: user) }
+      #let(:user) { FactoryBot.create(:admin) }
+      let(:nodes) do
+        [
+            {
+                "label": "Chapter 1",
+                "nodes": [
+                    {
+                        "proxy": file_set.id
+                    }
+                ]
+            }
+        ]
+      end
+
+      before do
+        sign_in user
+        resource.ordered_members << file_set
+        resource.save
+      end
+
+      it "persists order" do
+        post :save_structure, nodes: nodes, id: resource.id, label: "TOP!"
+
+        expect(response.status).to eq 200
+        expect(resource.reload.logical_order.order) \
+        .to eq({ "label": "TOP!", "nodes": nodes }.with_indifferent_access)
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Adding ability to persist structure by integrating logical order classes from Pumpkin.  This ability only exists in the PagedResource archetype and can be exercised in the console as follows:

Create FileSet and PagedResource:
```
file_set = FileSet.new(title: ["Section 1"])
paged = PagedResource.new(title: ['New work'])
```
Add FileSet to PagedResource:
```
paged.ordered_members << file_set
paged.save
```
Manually create a structure for the PagedResource containing the member FileSet:
```
nodes = {"label": "Chapter 1", "nodes": [{"proxy": file_set.id}]}
```
Save the structure to PagedResource using the new logical order methods mixed into the model:
```
paged.logical_order.order = nodes
```

PagedResource now has logical order reflecting the structure that can be used in the UI (i.e. to deliver a IIIF manifest)
```
paged.logical_order
paged.logical_order.order
```