### PR TITLE
HPT-1408 Test suite improvements

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,5 +40,5 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   #
-  config.active_job.queue_adapter = :inline
+  # config.active_job.queue_adapter = :inline
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,7 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
+ActiveJob::Base.queue_adapter = :test
 
 # @note In January 2018, TravisCI disabled Chrome sandboxing in its Linux
 #       container build environments to mitigate Meltdown/Spectre

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,39 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  # Use this example metadata when you want to perform jobs inline during testing.
+  #
+  #   describe '#my_method`, :perform_enqueued do
+  #     ...
+  #   end
+  #
+  # If you pass an `Array` of job classes, they will be treated as the filter list.
+  #
+  #   describe '#my_method`, perform_enqueued: [MyJobClass] do
+  #     ...
+  #   end
+  #
+  # Limit to specific job classes with:
+  #
+  #   ActiveJob::Base.queue_adapter.filter = [JobClass]
+  #
+  config.before(:example, :perform_enqueued) do |example|
+    ActiveJob::Base.queue_adapter.filter =
+        example.metadata[:perform_enqueued].try(:to_a)
+
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs    = true
+    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = true
+  end
+
+  config.after(:example, :perform_enqueued) do
+    ActiveJob::Base.queue_adapter.filter         = nil
+    ActiveJob::Base.queue_adapter.enqueued_jobs  = []
+    ActiveJob::Base.queue_adapter.performed_jobs = []
+
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs    = false
+    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = false
+  end
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin

--- a/spec/support/shared_examples/paged_structured_controller.rb
+++ b/spec/support/shared_examples/paged_structured_controller.rb
@@ -9,7 +9,7 @@ do |resource_symbol, presenter_factory|
     let(:user) { FactoryBot.create(:user) }
 
     before { sign_in user }
-    describe "#structure" do
+    describe "#structure", :clean do
 
       let(:solr) { ActiveFedora.solr.conn }
       let(:resource) do
@@ -51,7 +51,7 @@ do |resource_symbol, presenter_factory|
       end
     end
 
-    describe "#save_structure" do
+    describe "#save_structure", :clean do
 
       let(:resource) { FactoryBot.create(resource_symbol, user: user) }
       let(:file_set) { FactoryBot.create(:file_set, user: user) }

--- a/spec/support/shared_examples/paged_structured_controller.rb
+++ b/spec/support/shared_examples/paged_structured_controller.rb
@@ -51,7 +51,7 @@ do |resource_symbol, presenter_factory|
       end
     end
 
-    describe "#save_structure", :clean do
+    describe "#save_structure", :clean, :perform_enqueued do
 
       let(:resource) { FactoryBot.create(resource_symbol, user: user) }
       let(:file_set) { FactoryBot.create(:file_set, user: user) }


### PR DESCRIPTION
Adding configuration to RSpec to provide the ability to properly clean the repositories/database in test examples. Also adds ability to force execution of enqueued jobs when directly or indirectly causing a job to be invoked that is set to perform_later.  Since the default for the queue adapter is 'async', test results could be unpredictable or fail.  This ability alleviates having to set it the adapter in environment configuration.

This PR contains tests that illustrate the use of metadata on examples to invoke abilities described above.