### PR TITLE
HPT-1408 Reference Hyrax factories in RSpec examples

### DIFF
--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -1,0 +1,12 @@
+# Provide a dummy GenericWork model to satisfy Hyrax FactoryBot factories.
+# It isn't available as a work type because it isn't complete and
+# isn't initialized on startup.
+class GenericWork < ActiveFedora::Base
+  include ::Hyrax::WorkBehavior
+
+  validates :title, presence: { message: 'Your work must have a title.' }
+
+  # This must be included at the end, because it finalizes the metadata
+  # schema (by adding accepts_nested_attributes)
+  include ::Hyrax::BasicMetadata
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,9 @@ class User < ApplicationRecord
   include LDAPGroupsLookup::Behavior
   alias_attribute :ldap_lookup_key, :username
 
+  # Provide dummy :password attribute to satisfy Hyrax FactoryBot factories
+  attr_accessor :password
+
   if Blacklight::Utils.needs_attr_accessible?
     attr_accessible :email, :password, :password_confirmation
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,5 +40,5 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   #
-  config.active_job.queue_adapter = :inline
+  # config.active_job.queue_adapter = :inline
 end

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -286,3 +286,16 @@ Date::DATE_FORMATS[:standard] = "%m/%d/%Y"
 Qa::Authorities::Local.register_subauthority('subjects', 'Qa::Authorities::Local::TableBasedAuthority')
 Qa::Authorities::Local.register_subauthority('languages', 'Qa::Authorities::Local::TableBasedAuthority')
 Qa::Authorities::Local.register_subauthority('genres', 'Qa::Authorities::Local::TableBasedAuthority')
+
+# Adding Hyrax's FactoryBot factories into the locations that definitions are initialized from.
+# This alleviates having to copy down common reusable factories.  To customize any factories
+# defined in the gem location, use the 'modify' method instead of 'define':
+#
+# FactoryBot.modify do
+#   factory :user do
+#     full_name     "Jane Doe"
+#     custom_attr        "Something"
+#   end
+# end
+hyrax_factories = File.join(Gem.loaded_specs['hyrax'].full_gem_path,"spec","factories")
+FactoryBot.definition_file_paths.unshift hyrax_factories

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -1,6 +1,5 @@
-FactoryBot.define do
-  # The ::FileSet model is defined in spec/internal/app/models by the
-  # curation_concerns:install generator.
+# We use modify instead of define because the actual factory is defined in hyrax/spec/factories
+FactoryBot.modify do
   factory :file_set, class: FileSet do
 
     transient do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,5 @@
-require 'factory_girl'
-
-FactoryGirl.define do
+# We use modify instead of define because the actual factory is defined in hyrax/spec/factories
+FactoryBot.modify do
   factory :user do
     sequence(:uid) { |n| "username#{n}" }
     sequence(:email) { |n| "email-#{srand}@test.com" }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,7 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
+ActiveJob::Base.queue_adapter = :test
 
 # @note In January 2018, TravisCI disabled Chrome sandboxing in its Linux
 #       container build environments to mitigate Meltdown/Spectre

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,39 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  # Use this example metadata when you want to perform jobs inline during testing.
+  #
+  #   describe '#my_method`, :perform_enqueued do
+  #     ...
+  #   end
+  #
+  # If you pass an `Array` of job classes, they will be treated as the filter list.
+  #
+  #   describe '#my_method`, perform_enqueued: [MyJobClass] do
+  #     ...
+  #   end
+  #
+  # Limit to specific job classes with:
+  #
+  #   ActiveJob::Base.queue_adapter.filter = [JobClass]
+  #
+  config.before(:example, :perform_enqueued) do |example|
+    ActiveJob::Base.queue_adapter.filter =
+        example.metadata[:perform_enqueued].try(:to_a)
+
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs    = true
+    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = true
+  end
+
+  config.after(:example, :perform_enqueued) do
+    ActiveJob::Base.queue_adapter.filter         = nil
+    ActiveJob::Base.queue_adapter.enqueued_jobs  = []
+    ActiveJob::Base.queue_adapter.performed_jobs = []
+
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs    = false
+    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = false
+  end
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin

--- a/spec/support/shared_examples/paged_structured_controller.rb
+++ b/spec/support/shared_examples/paged_structured_controller.rb
@@ -9,7 +9,7 @@ do |resource_symbol, presenter_factory|
     let(:user) { FactoryBot.create(:user) }
 
     before { sign_in user }
-    describe "#structure" do
+    describe "#structure", :clean do
 
       let(:solr) { ActiveFedora.solr.conn }
       let(:resource) do
@@ -51,7 +51,7 @@ do |resource_symbol, presenter_factory|
       end
     end
 
-    describe "#save_structure" do
+    describe "#save_structure", :clean do
 
       let(:resource) { FactoryBot.create(resource_symbol, user: user) }
       let(:file_set) { FactoryBot.create(:file_set, user: user) }

--- a/spec/support/shared_examples/paged_structured_controller.rb
+++ b/spec/support/shared_examples/paged_structured_controller.rb
@@ -51,7 +51,7 @@ do |resource_symbol, presenter_factory|
       end
     end
 
-    describe "#save_structure", :clean do
+    describe "#save_structure", :clean, :perform_enqueued do
 
       let(:resource) { FactoryBot.create(resource_symbol, user: user) }
       let(:file_set) { FactoryBot.create(:file_set, user: user) }


### PR DESCRIPTION
Adding ability through configuration to reference FactroyBot factories in the Hyrax test suite.  The benefit of doing so is that we can access Hyrax's full set of factories that will usually be exactly what is needed to setup a test example.  The alleviates literally copying them down and then trying to keep them in sync through version upgrades.

This is done by adding the gem's spec directory on disk to the locations that are searched for factories to initialize. This has to be done before RSpec/FactoryBot initializes so the line that adds the new location is located in the main Hyrax initializer.

**Implications**
There are several implications to doing this.  First, it is not going to be obvious that there are named factories referenced elsewhere since this isn't an overly familiar pattern and this will be compounded by the fact that the code that sets it up won't be in any of the spec helpers so it won't be obvious.  Secondly, any time the behavior of a factory needs to be tweaked for local use cases, the `modify` method must be used instead of `define` or tests will fail due to duplicate name error.  Being able to extend/override an existing factory is good and very flexible but the problem is that you may not know that factories are being referenced elsewhere (see point # 1) and the resulting duplicate name error would be perplexing.

Factories can be overridden like:

```
FactoryBot.modify do
   factory :user do  # This named factory must be defined elsewhere first
     full_name     "Jane Doe"
     custom_attr  "Something"
   end
end
```