### PR TITLE
HPT-1442 Adding missing file related environment variables

### DIFF
--- a/catorax_config.example.yml
+++ b/catorax_config.example.yml
@@ -1,4 +1,13 @@
 development: &development
+  store_original_files: <%= ENV["PMP_STORE_ORIGINAL_FILES"] || true %>
+  master_file_service_url: <%= ENV["PMP_MASTER_FILE_SERVICE_URL"] || "http://purl.dlib.indiana.edu/iudl/variations/master" %>
+  access_file_service_url: <%= ENV["PMP_ACCESS_FILE_SERVICE_URL"] || "http://purl.dlib.indiana.edu/iudl/variations/access" %>
+  purl_redirect_url: <%= ENV["PMP_PURL_REDIRECT_URL"] || "http://server1.variations2.indiana.edu/cgi-bin/access?%s" %>
+  create_hocr_files: <%= ENV["PMP_CREATE_HOCR_FILES"] || true %>
+  index_hocr_files: <%= ENV["PMP_INDEX_HOCR_FILES"] || true %>
+  create_word_boundaries: <%= ENV["PMP_CREATE_WORD_BOUNDARIES"] || true %>
+  allow_pdf_download: <%= ENV["PMP_ALLOW_PDF_DOWNLOAD"] || false %>
+
   fedora:
     user: fedoraAdmin
     password: fedoraAdmin
@@ -17,7 +26,7 @@ development: &development
     serve_static_files: true
     secret_key_base: 628b30efcdf28acbbd30a80e53e2b743d44f74bf393462badc49e0f5909ed109812ff12905e3a98bf4f81d3618fac5c061ad4e1ca5c91f9c1dce8226ca3cff25
   derivatives:
-    path: tmp/derivatives
+    path: <%= Rails.root.join("tmp/derivatives") %>
   ldap:
     enabled: false
     host: ads.iu.edu
@@ -49,5 +58,5 @@ test:
       serve_static_files: true
       secret_key_base: c9dd75fe2cce941807d14e04c09aa1f9ae41b6e1f7ba9d2f33142659acf9491f4a7835aad0c4110bf2fa40f2a1e6f7a62048b5a1e1a32c361c8c16d772e40bf0
   derivatives:
-    path: tmp/derivatives
+    path: <%= Rails.root.join("tmp/derivatives") %>
 production: *development

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,7 +52,5 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  # Added to get actor/job stack working in dev console, rake tasks
   # config.active_job.queue_adapter = :inline
-  config.active_job.queue_adapter = :sidekiq
 end


### PR DESCRIPTION
Adds missing file related environment variables in new configuration structure. These did exist in config/config.yml but the new structure introduced in https://github.com/IUBLibTech/catorax/pull/17 supersedes the `Catorax.config` configuration namespace.  The absence of these variables will cause failures in the file creation/characterization job pipeline but may not be apparent if processing is asynchronous (i.e. sidekiq) because failures won't be fatal to saving the work.

This also refines the derivatives path variable to ensure the default path is relative to the Rails root.  My desk checking experience showed that the lack of a leading directory slash would cause the hydra-derivatives gem to truncate `tmp/derivatives` to be `/derivatives` and thus cause write permission errors.  Again this may not be apparent depending on job queue configuration.