### PR TITLE
Use LDAP lookup for user email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,7 +60,8 @@ class User < ApplicationRecord
     where(provider: auth.provider, uid: auth.uid).first_or_create! do |user|
       user.provider = auth.provider
       user.uid = auth.uid
-      user.email = [auth.uid,'@indiana.edu'].join
+      user.email = user.try(:ldap_mail)
+      user.email = [auth.uid,'@indiana.edu'].join if user.email.blank?
     end
   end
 end


### PR DESCRIPTION
Requires using an updated `ldap_groups_lookup` gem (with pr #3 merged) to take effect.
Retains the original string concatenation as a backup check against blank results, to satisfy the uniqueness constraint on `user.email`